### PR TITLE
Fixing whale home sites SSL

### DIFF
--- a/habitat/config/nginx.conf
+++ b/habitat/config/nginx.conf
@@ -35,19 +35,27 @@ http {
 {{ #if cfg.home-whale-dis.domain_names ~}}
 {{~#eachAlive bind.home-whale-dis.members as |home-whale-dis|}}
 {{~#if @last}}
+    {{ #if cfg.home-whale-dis.ssl_certificate ~}}
     server {
           listen 80;
           listen [::]:80;
 
           server_name {{strJoin cfg.home-whale-dis.domain_names " "}};
+          return 301 https://$host$request_uri;
+    }
 
-          {{ #if cfg.home-whale-dis.ssl_certificate ~}}
+    server {
           ssl_certificate {{cfg.home-whale-dis.ssl_certificate}};
           ssl_certificate_key {{cfg.home-whale-dis.ssl_certificate_key}};
           include /etc/letsencrypt/options-ssl-nginx.conf;
           listen 443 ssl;
-          {{ /if ~ }}
+    {{else ~}}
+    server {
+          listen 80;
+          listen [::]:80;
+    {{/if ~}}
 
+          server_name {{strJoin cfg.home-whale-dis.domain_names " "}};
           client_max_body_size 100M;
 
           location / {


### PR DESCRIPTION
Redirecting from port 80 to port 443 for the http://www.whaledisentanglement.org/